### PR TITLE
Add nginx SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,7 @@ Installs Oracle JDK
 
 #### nginx
 If `node[sonarqube][use_nginx]` is set to `true` this recipe will be included
-in the run_list and configure nginx as a reverse proxy for SonarQube. This recipe
-currently does not support SSL/TLS configuration, but will in the near future.
+in the run_list and configure nginx as a reverse proxy for SonarQube.
 
 #### postgresql
 Installs postgresql and if `node['sonarqube']['jdbc']['password'] is not set it

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,4 @@ default['sonarqube']['db']['name'] = 'sonarqube'
 default['sonarqube']['db']['host'] = 'localhost'
 default['sonarqube']['jdbc']['url'] = "jdbc:postgresql://#{node['sonarqube']['db']['host']}:#{node['postgresql']['config']['port']}/#{node['sonarqube']['db']['name']}?useUnicode=true&amp;characterEncoding=utf8"
 default['sonarqube']['use_nginx'] = true
-default['sonarqube']['nginx_template'] = 'sonarqube_nginx.conf.erb'
-default['sonarqube']['reverse_proxy_port'] = 9000
 default['sonarqube']['wrapper']['jvm']['maxmemory'] = 2048

--- a/attributes/nginx.rb
+++ b/attributes/nginx.rb
@@ -1,3 +1,13 @@
 override['nginx']['default_site_enabled'] = false
 override['nginx']['client_max_body_size'] = 0
 
+default['sonarqube']['nginx_template'] = 'sonarqube_nginx.conf.erb'
+default['sonarqube']['reverse_proxy_port'] = 9000
+
+default['sonarqube']['http']['host_name'] = node['fqdn']
+default['sonarqube']['http']['host_aliases'] = []
+default['sonarqube']['http']['port'] = 80
+default['sonarqube']['http']['ssl']['port'] = 443
+default['sonarqube']['http']['ssl']['enabled'] = false
+default['sonarqube']['http']['ssl']['cert_databag'] = 'sonarqube'
+default['sonarqube']['http']['ssl']['cert_databag_item'] = 'ssl_cert'

--- a/libraries/sonarqube_helpers.rb
+++ b/libraries/sonarqube_helpers.rb
@@ -1,0 +1,22 @@
+module SonarQube
+  class Helpers
+    class << self
+
+      # Loads the given data bag.  The databag can be encrypted or unencrypted.
+      def load_data_bag(data_bag, name)
+        raw_hash = Chef::DataBagItem.load(data_bag, name)
+        encrypted = raw_hash.detect do |key, value|
+          if value.is_a?(Hash)
+            value.has_key?("encrypted_data")
+          end
+        end
+        if encrypted
+          secret = Chef::EncryptedDataBagItem.load_secret
+          Chef::EncryptedDataBagItem.new(raw_hash, secret)
+        else
+          raw_hash
+        end
+      end
+    end
+  end
+end

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -3,13 +3,13 @@
 # Recipe:: nginx
 #
 # Copyright (C) 2014 Ryan Hass
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,12 +19,47 @@
 
 include_recipe 'nginx'
 
+if node['sonarqube']['http']['ssl']['enabled']
+  ssl_data_bag = SonarQube::Helpers.load_data_bag(
+    node['sonarqube']['http']['ssl']['cert_databag'],
+    node['sonarqube']['http']['ssl']['cert_databag_item']
+  )
+
+  # Public key.
+  file "/etc/ssl/certs/#{node['sonarqube']['http']['host_name']}.crt" do
+    mode 0644
+    user 'root'
+    group 'root'
+    content "#{ssl_data_bag['cert']}"
+    notifies :reload, 'service[nginx]', :delayed
+  end
+
+  # Private key.
+  file "/etc/ssl/private/#{node['sonarqube']['http']['host_name']}.key" do
+    mode 0600
+    user 'root'
+    group 'root'
+    content "#{ssl_data_bag['key']}"
+    notifies :reload, 'service[nginx]', :delayed
+  end
+end
+
 template ::File.join(node['nginx']['dir'], 'sites-available', 'sonarqube') do
   source node['sonarqube']['nginx_template']
+  notifies :reload, 'service[nginx]', :delayed
   mode 0644
   owner 'root'
   group 'root'
   action :create
+  variables(
+    :host_name          => node['sonarqube']['http']['host_name'],
+    :host_aliases       => node['sonarqube']['http']['host_aliases'] || [],
+    :ssl_enabled        => node['sonarqube']['http']['ssl']['enabled'],
+    :redirect_http      => node['sonarqube']['http']['ssl']['enabled'],
+    :listen_port        => node['sonarqube']['http']['port'],
+    :ssl_listen_port    => node['sonarqube']['http']['ssl']['port'],
+    :reverse_proxy_port => node['sonarqube']['reverse_proxy_port']
+  )
 end
 
 nginx_site 'sonarqube' do

--- a/templates/default/sonarqube_nginx.conf.erb
+++ b/templates/default/sonarqube_nginx.conf.erb
@@ -1,11 +1,39 @@
+# THIS FILE IS MANAGED BY CHEF
+# Local modifications will be discarded.
+
+<% if @redirect_http %>
 server {
-  listen  80 default;
-  server_name <%= node['fqdn'] %>;
+  listen       <%= @listen_port %>;
+  server_name  <%= @host_name %> <%= @host_aliases.join(' ') %>;
+  rewrite      ^(.*) https://$host$1 permanent;
+}
+<% end -%>
+
+server {
+<% if @ssl_enabled -%>
+  listen      <%= @ssl_listen_port %>;
+<% else -%>
+  listen      <%= @listen_port %>;
+<% end -%>
+
+  server_name <%= @host_name %> <%= @host_aliases.join(' ') %>;
+
+<% if @ssl_enabled -%>
+  ssl on;
+  ssl_certificate     /etc/ssl/certs/<%= @host_name %>.crt;
+  ssl_certificate_key /etc/ssl/private/<%= @host_name %>.key;
+
+  ssl_ciphers               EECDH+AES128:RSA+AES128:EECDH+AES256:RSA+AES256:EECDH+3DES:RSA+3DES:!MD5;
+  ssl_prefer_server_ciphers on;
+
+  ssl_session_cache   shared:SSL:10m;
+  ssl_session_timeout 10m;
+<% end -%>
 
   location / {
-    proxy_pass              http://localhost:<%= node['sonarqube']['reverse_proxy_port'] %>/;
+    proxy_pass              http://localhost:<%= @reverse_proxy_port %>/;
     proxy_set_header        X-Real-IP   $remote_addr;
     proxy_set_header        Host        $host;
-    proxy_set_header        X-Forwarded-Proto http;
+    proxy_set_header        X-Forwarded-Proto $scheme;
   }
 }


### PR DESCRIPTION
This adds SSL support to the nginx proxy.  It is off by default to maintain default functionality.

To enable SSL support:
- [ ] Set `default['sonarqube']['http']['ssl']['enabled'] = true`
- [ ] Create a sonarqube/ssl_cert data bag with `cert` and `key` attributes.  This can be an encrypted data bag or regular data bag
